### PR TITLE
Remove Kora prefix from tests

### DIFF
--- a/lib/dynamic.ex
+++ b/lib/dynamic.ex
@@ -21,7 +21,7 @@ defmodule Dynamic do
 	@doc ~S"""
 	Gets value at path or falls back
 	## Examples
-		iex> Kora.Dynamic.get(%{a: %{b: 1}}, [:a, :b])
+		iex> Dynamic.get(%{a: %{b: 1}}, [:a, :b])
 		1
 	"""
 	def get(input, path) do
@@ -30,7 +30,7 @@ defmodule Dynamic do
 	@doc ~S"""
 	Gets value at path or falls back
 	## Examples
-		iex> Kora.Dynamic.get(%{a: %{b: 1}}, [:a, :b, :c], :foo)
+		iex> Dynamic.get(%{a: %{b: 1}}, [:a, :b, :c], :foo)
 		:foo
 	"""
 	def get(input, path, fallback) do
@@ -40,7 +40,7 @@ defmodule Dynamic do
 	@doc ~S"""
 	Default to fallback if input is nil
 	## Examples
-		iex> Kora.Dynamic.default(nil, :foo)
+		iex> Dynamic.default(nil, :foo)
 		:foo
 	"""
 	def default(input, fallback), do: default(input, fallback, nil)
@@ -48,7 +48,7 @@ defmodule Dynamic do
 	@doc ~S"""
 	Default to fallback if input is equal to compare
 	## Examples
-		iex> Kora.Dynamic.default(:bar, :foo, :bar)
+		iex> Dynamic.default(:bar, :foo, :bar)
 		:foo
 	"""
 	def default(input, fallback, compare) when input == compare, do: fallback
@@ -56,7 +56,7 @@ defmodule Dynamic do
 	@doc ~S"""
 	Defaults to input if not equal to compare
 	## Examples
-		iex> Kora.Dynamic.default(:foo, :bar, :boo)
+		iex> Dynamic.default(:foo, :bar, :boo)
 		:foo
 	"""
 	def default(input, _compare, _default), do: input
@@ -64,7 +64,7 @@ defmodule Dynamic do
 	@doc ~S"""
 	Defaults to input if not equal to compare
 	## Examples
-		iex> Kora.Dynamic.default(:foo, :bar, :boo)
+		iex> Dynamic.default(:foo, :bar, :boo)
 		:foo
 	"""
 	def put(input, [head], value), do: Map.put(input, head, value)

--- a/test/dynamic_ex_test.exs
+++ b/test/dynamic_ex_test.exs
@@ -1,8 +1,4 @@
 defmodule DynamicTest do
   use ExUnit.Case
   doctest Dynamic
-
-  test "greets the world" do
-    assert Dynamic.hello() == :world
-  end
 end


### PR DESCRIPTION
was getting these errors with each test: 

```  1) test doc at Dynamic.put/3 (5) (DynamicTest)
     test/dynamic_ex_test.exs:3
     Doctest failed: got UndefinedFunctionError with message "function Kora.Dynamic.default/3 is undefined (module Kora.Dynamic is not available)"
     code: Kora.Dynamic.default(:foo, :bar, :boo)
     stacktrace:
       Kora.Dynamic.default(:foo, :bar, :boo)
       (for doctest at) lib/dynamic.ex:67: (test)
```

Problem is that Dynamic was abstracted into it's own repo, but the `Kora` prefixed remain. All tests pass after removing the Kora prefix: 

```
Finished in 0.06 seconds
5 tests, 0 failures
```